### PR TITLE
Handle negative index in `Index`

### DIFF
--- a/src/prelude.cog
+++ b/src/prelude.cog
@@ -215,6 +215,8 @@ Def Index (
 	Let N be Integer!;
 	Let L be List!;
 
+	When < 0 N ( Error Join "Invalid index " Show N );
+
 	Do If Zero? N ( return First element of L )
 	else (
 		When Empty? L ( Error "Index is beyond end of list" );


### PR DESCRIPTION
Alternatively, `Index is beyond end of list` could just be updated to include the "before the start of list" case, but this approach prevents exhausting the list before throwing the error 🤷 