### PR TITLE
Add tests for stop

### DIFF
--- a/tests/stop-begin.cog
+++ b/tests/stop-begin.cog
@@ -1,0 +1,8 @@
+Begin (
+	Def Exit;
+	Do (
+		Print "PASS: Stop in begin";
+		Stop;
+	);
+	Print "FAIL: Stop in begin";
+);

--- a/tests/stop.cog
+++ b/tests/stop.cog
@@ -1,0 +1,7 @@
+Def F (
+	Print "PASS: Stop";
+	Stop;
+	Print "FAIL: Stop";
+);
+
+F;


### PR DESCRIPTION
Opening a PR to draw your attention (sorry) in case you have better ideas for some of these:
- Tests had to be split due to the nature of that function
- On failure it would print both a PASS and a FAIL since we can't print anything after `Stop` successfully stops execution - if you can think of a better way I'd be glad!
- Begin is tested because both begin and stop are implemented with catching errors in cognatejs, it might be helpful since these tests could be used for alternative cognate implementations